### PR TITLE
changing getInt to getLong for buildNumber greater INT_MAX

### DIFF
--- a/hockeysdk/src/main/java/net/hockeyapp/android/Constants.java
+++ b/hockeysdk/src/main/java/net/hockeyapp/android/Constants.java
@@ -187,7 +187,7 @@ public class Constants {
             ApplicationInfo appInfo = packageManager.getApplicationInfo(context.getPackageName(), PackageManager.GET_META_DATA);
             Bundle metaData = appInfo.metaData;
             if (metaData != null) {
-                return metaData.getInt(BUNDLE_BUILD_NUMBER, 0);
+                return metaData.getLong(BUNDLE_BUILD_NUMBER, 0);
             }
         } catch (PackageManager.NameNotFoundException e) {
             HockeyLog.error("Exception thrown when accessing the application info:");


### PR DESCRIPTION
this change is to use Long instead of int in loadBuildNumber() function in Constants.java, as in our case build number is more than 10 digits which crosses INT_MAX limit.
